### PR TITLE
Method `ensureError` works incorrectly for errors inherited from Terror

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ try {
         // throw new MyError(MyError.CODES.STRANGE_THING_HAPPENS);
     }
 } catch (err) {
-    // ensureError method returns err if it is an instance of Terror,
-    // otherwise wrap Error instance in the Terror with default code UNKNOWN_ERROR
+    // ensureError method returns err if it is an instance of MyError,
+    // otherwise wrap Error instance in the MyError with default code UNKNOWN_ERROR
     MyError.ensureError(err)
         .log();
 }
@@ -169,8 +169,8 @@ Terror.createError(MyError.CODES.IO_ERROR);
 
 ### ensureError(originalError, code)
 
-Returns `originalError` if it's an instance of `Terror`.
-Otherwise wrap `originalError` into new `Terror` instance using `code` or `UNKNOWN_ERROR` code if second argument is absent.
+Returns `originalError` if it's an instance of the owning class.
+Otherwise wrap `originalError` into new owning class instance using `code` or `UNKNOWN_ERROR` code if second argument is absent.
 
 Example:
 ```javascript
@@ -189,7 +189,7 @@ arr.forEach(function(item) {
         }
     } catch (err) {
         throw MyError.ensureError(err, MyError.CODES.UNEXPECTED_ERROR)
-            .log();
+            .log(); // logging like MyError instance
     }
 })
 ```

--- a/lib/terror.js
+++ b/lib/terror.js
@@ -280,7 +280,7 @@ Terror.createError = function(code, message) {
  * @returns {Terror}
  */
 Terror.ensureError = function(error, code) {
-    if ( ! (error instanceof Terror)) {
+    if ( ! (error instanceof this)) {
         error = this.createError(typeof code === 'undefined' || code === null ? Terror.CODES.UNKNOWN_ERROR : code, error);
     }
 

--- a/test/terror.js
+++ b/test/terror.js
@@ -262,6 +262,8 @@ module.exports = {
     "ensureError" : function(test) {
         var rawError = new Error('test error'),
             terror = new Terror(null, 'test error'),
+            ChildError = Terror.create('ChildError', {}),
+            childError = new ChildError(null, 'test child terror error'),
             ensuredError,
             code = 42,
             zeroCode = 0,
@@ -298,6 +300,40 @@ module.exports = {
             ensuredError = Terror.ensureError(err);
 
             test.strictEqual(ensuredError, terror, 'original Terror instance is the same object as of ensured error');
+        }
+
+        ensuredError = undefined;
+
+        try {
+            throw rawError;
+        } catch (err) {
+            ensuredError = ChildError.ensureError(err);
+
+            test.ok(ensuredError instanceof Terror, 'ensured as ChildError error is an instance of the Terror');
+            test.ok(ensuredError instanceof ChildError, 'ensured as ChildError error is an instance of the ChildError');
+        }
+
+        ensuredError = undefined;
+
+        try {
+            throw terror;
+        } catch (err) {
+            ensuredError = ChildError.ensureError(err);
+
+            test.notEqual(err, ensuredError, 'ensured as ChildError error is not the same as error of Terror');
+            test.strictEqual(ensuredError.originalError, err, 'ensured as ChildError error refers to the original error of Terror');
+            test.ok(ensuredError instanceof Terror, 'ensured as ChildError error is an instance of the Terror');
+            test.ok(ensuredError instanceof ChildError, 'ensured as ChildError error is an instance of the ChildError');
+        }
+
+        ensuredError = undefined;
+
+        try {
+            throw childError;
+        } catch (err) {
+            ensuredError = ChildError.ensureError(err);
+
+            test.strictEqual(err, ensuredError, 'original ChildError instance is the same object as of ensured error');
         }
 
         test.done();


### PR DESCRIPTION
`ensureError` should return instance of the owning class.

For example:

``` javascript
try {
    throw new Terror('foo');
} catch(err) {
   console.log(MyError.ensureError(err) instanceof MyError); // false, but why?
}
```
