### PR TITLE
Use Error.captureStackTrace instead stack modification

### DIFF
--- a/lib/terror.js
+++ b/lib/terror.js
@@ -41,12 +41,7 @@ function Terror(code, message) {
         return new Terror(code, message);
     }
 
-    var stack = (new Error()).stack.split('\n');
-
-    stack.splice(0, 2);
-    stack.unshift(this.constructor.prototype.name);
-
-    this.stack = stack.join('\n');
+    Error.captureStackTrace(this, Terror);
 
     this.code = typeof code === 'undefined' || code === null ? Terror.CODES.UNKNOWN_ERROR : code;
     this.codeName = this.constructor.CODE_NAMES[this.code] || this.code;


### PR DESCRIPTION
- https://code.google.com/p/v8-wiki/wiki/JavaScriptStackTraceApi
- Now stack trace contains error message like native errors:

```
[kostya@arch terror]$ node
> throw new Error('msg')
Error: msg
    at repl:1:7
    at REPLServer.self.eval (repl.js:110:21)
    at repl.js:249:20
    at REPLServer.self.eval (repl.js:122:7)
    at Interface.<anonymous> (repl.js:239:12)
    at Interface.emit (events.js:95:17)
    at Interface._onLine (readline.js:202:10)
    at Interface._line (readline.js:531:8)
    at Interface._ttyWrite (readline.js:760:14)
    at ReadStream.onkeypress (readline.js:99:10)
> var Terror = require('./lib/terror')
undefined
> throw new Terror(500, 'msg')
Terror: msg
    at repl:1:7
    at REPLServer.self.eval (repl.js:110:21)
    at repl.js:249:20
    at REPLServer.self.eval (repl.js:122:7)
    at Interface.<anonymous> (repl.js:239:12)
    at Interface.emit (events.js:95:17)
    at Interface._onLine (readline.js:202:10)
    at Interface._line (readline.js:531:8)
    at Interface._ttyWrite (readline.js:760:14)
    at ReadStream.onkeypress (readline.js:99:10)
> 
```
