### PR TITLE
Next level!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.DS_Store
 /.idea
 /node_modules
+/benchmark/node_modules

--- a/.jshintrc
+++ b/.jshintrc
@@ -8,7 +8,7 @@
      // This option requires you to always put curly braces around blocks in loops and conditionals.
     "curly" : true,
 
-     // This options prohibits the use of == and != in favor of === and!==.
+     // This options prohibits the use of == and != in favor of === and !==.
     "eqeqeq" : true,
 
      // This option requires all for in loops to filter object' sitems.
@@ -20,8 +20,8 @@
      // This option enforces specific tab width for your code.
      "indent" : 4,
 
-     // This option prohibits the use of a variable before it was defined.
-    "latedef" : true,
+     // This option prohibits the use of a variable and function before it was defined.
+    "latedef" : "nofunc",
 
      // This option requires you to capitalize names of constructor functions.
     "newcap" : true,
@@ -79,7 +79,7 @@
     "debug" : false,
 
      // This option suppresses warnings about == null comparisons.
-    "eqnull" : false,
+    "eqnull" : true,
 
      // This option tells JSHint that your code uses ECMAScript 5 specific features such as getters and setters.
     "es5" : false,
@@ -87,8 +87,8 @@
      // This option tells JSHint that your code uses ES.next specific features such as const.
     "esnext" : false,
 
-     // This option suppresses warnings about the use of eval.
-    "evil" : false,
+     // This option suppresses warnings about the use of eval and new Function().
+    "evil" : true,
 
      // This option suppresses warnings about the use of expressions
      // where normally you would expect to see assignments or function calls.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ try {
 ## Constructor
 
 ```javascript
+new Terror(code, originalError);
 new Terror(code, message);
 new Terror(code);
 new Terror();

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,1 @@
+Run `npm test`.

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,0 +1,12 @@
+{
+    "name" : "terror-benchmark",
+    "version" : "1.2.0",
+    "dependencies": {
+      "terror" : "git://github.com/nodules/terror.git#1.1.0",
+      "benchmark" : "1.0.0"
+    },
+    "scripts": {
+        "test": "npm install && node start.js"
+    },
+    "private" : true
+}

--- a/benchmark/start.js
+++ b/benchmark/start.js
@@ -1,0 +1,101 @@
+var Benchmark = require('benchmark');
+var oldTerror = require('terror');
+var newTerror = require('../lib/terror');
+
+var MSG = 'Error %value%';
+var DATA = {
+    value: 'message'
+};
+
+var MyOldError = oldTerror.create('MyOldError', {
+    MY: MSG
+});
+
+var MyNewError = newTerror.create('MyNewError', {
+    MY: MSG
+});
+
+var suits = [{
+    name: 'new Terror(null, message)',
+    Old: function () {
+        new oldTerror(null, MSG);
+    },
+    New: function () {
+        new newTerror(null, MSG);
+    }
+}, {
+    name: 'Terror.createError(null, message)',
+    Old: function () {
+        oldTerror.createError(null, MSG);
+    },
+    New: function () {
+        newTerror.createError(null, MSG);
+    }
+}, {
+    name: 'Terror.ensureError(error)',
+    Old: function () {
+        oldTerror.ensureError(new Error(MSG));
+    },
+    New: function () {
+        newTerror.ensureError(new Error(MSG));
+    }
+}, {
+    name: 'new MyError(null, message)',
+    Old: function () {
+        new MyOldError(null, MSG);
+    },
+    New: function () {
+        new MyNewError(null, MSG);
+    }
+}, {
+    name: 'MyError.createError(null, message)',
+    Old: function () {
+        MyOldError.createError(null, MSG);
+    },
+    New: function () {
+        MyNewError.createError(null, MSG);
+    }
+}, {
+    name: 'MyError.createError(code, data)',
+    Old: function () {
+        MyOldError.createError(MyOldError.CODES.MY, DATA);
+    },
+    New: function () {
+        MyNewError.createError(MyNewError.CODES.MY, DATA);
+    }
+}, {
+    name: 'MyError.ensureError(error, code)',
+    Old: function () {
+        MyOldError.ensureError(MSG, MyNewError.CODES.MY);
+    },
+    New: function () {
+        MyNewError.createError(MSG, MyNewError.CODES.MY);
+    }
+}];
+
+function onComplete() {
+    console.log('\tFastest is "' + this.filter('fastest').pluck('name') + '"\n');
+}
+
+function onStart() {
+    console.log(this.name + ':');
+}
+
+function onCycle(event) {
+    console.log('\t' + String(event.target));
+}
+
+var length = suits.length;
+var index = 0;
+
+while (index < length) {
+    var suit = suits[index++];
+
+    new Benchmark.Suite(suit.name)
+        .add('Old', suit.Old)
+        .add('New', suit.New)
+        .on('start', onStart)
+        .on('cycle', onCycle)
+        .on('complete', onComplete)
+        .run();
+}

--- a/lib/terror.js
+++ b/lib/terror.js
@@ -1,20 +1,11 @@
-var util = require('util');
+'use strict';
 
-function _has(obj, propName) {
-    return Object.prototype.hasOwnProperty.call(obj, propName);
-}
-
-function _copyPlainObject(src) {
-    var o = {};
-    Object.keys(src).forEach(function(key) {
-        o[key] = src[key];
-    });
-    return o;
-}
+var ERROR_CODE = 'Terror codes collision detected in the %name%&.extendCodes call for code "%code%"';
+var SOURCE_CONSTRUCTOR = 'return function %name% (code, message) {Terror.call(this, code, message)}';
 
 /**
  * @constructor
- * @param {Number} [code=Terror.CODES.UNKNOWN_ERROR]
+ * @param {String|Number} [code=Terror.CODES.UNKNOWN_ERROR]
  * @param {String} [message]
  * @returns {Terror}
  * @example
@@ -48,49 +39,93 @@ function _copyPlainObject(src) {
  *      ```
  */
 function Terror(code, message) {
-    Error.apply(this);
+    var msg;
+    var original;
 
-    this._isTerror = true;
+    this.code = code == null ? Terror.CODES.UNKNOWN_ERROR : code;
 
-    this.message = '$$MESSAGE$$';
-    Error.captureStackTrace(this, this.constructor);
-    this._stackTemplate = this.stack;
+    if (isString(message)) {
+        msg = message;
+    } else {
+        msg = this.constructor.MESSAGES[this.code];
 
-    this.code = typeof code === 'undefined' || code === null ? Terror.CODES.UNKNOWN_ERROR : code;
-    this.setMessage(message || this.constructor.MESSAGES[this.code]);
+        if (isError(message)) {
+            original = message;
+        }
+    }
+
     this.data = {};
-}
-util.inherits(Terror, Error);
+    this.message = msg;
+    this.originalError = original;
+    this._isTerror = true;
+    this._isLogged = false;
 
-Terror.prototype.name = 'Terror';
+    return captureStackTrace(this, this.constructor);
+}
+
+inherits(Terror, Error);
+
+module.exports = Terror;
+
+/**
+ *
+ * @type {String}
+ * @default 'ERROR'
+ */
+Terror.DEFAULT_ERROR_LEVEL = 'ERROR';
+
+/**
+ *
+ * @type {Object}
+ */
+Terror.CODES = {
+    UNKNOWN_ERROR: 'UNKNOWN_ERROR'
+};
+
+/**
+ *
+ * @type {Object}
+ */
+Terror.MESSAGES = {
+    UNKNOWN_ERROR: 'Unknown error'
+};
+
+/**
+ *
+ * @type {Number}
+ * @default 10
+ */
+Terror.stackTraceLimit = 10;
 
 /**
  * @param {String} name Error class name
  * @param {Object} [codes] hash { ERROR_CODE: 'error message', … }
  */
 Terror.create = function(name, codes) {
-    var Super = this,
-        Inheritor = function(code, message) {
-            Super.call(this, code, message);
-        };
-    util.inherits(Inheritor, Super);
+    var Inheritor = new Function('Terror', sPrintF(SOURCE_CONSTRUCTOR, {
+        name: name
+    }))(Terror);
 
-    Inheritor.prototype.name = name;
+    inherits(Inheritor, this);
 
     // link contructors methods
-    Inheritor.create = Super.create;
-    Inheritor.extendCodes = Super.extendCodes;
-    Inheritor.setLogger = Super.setLogger;
-    Inheritor.createError = Super.createError;
-    Inheritor.ensureError = Super.ensureError;
-    // copy static fields
-    Inheritor.CODES = _copyPlainObject(Super.CODES);
-    Inheritor.MESSAGES = _copyPlainObject(Super.MESSAGES);
-    Inheritor.DEFAULT_ERROR_LEVEL = Super.DEFAULT_ERROR_LEVEL;
+    Inheritor.create = this.create;
+    Inheritor.extendCodes = this.extendCodes;
+    Inheritor.setLogger = this.setLogger;
+    Inheritor.createError = this.createError;
+    Inheritor.ensureError = this.ensureError;
+    Inheritor.stackTraceLimit = this.stackTraceLimit;
 
-    if (typeof codes === 'object' && codes !== null) {
+    // copy static fields
+    Inheritor.CODES = copyPlainObject(this.CODES);
+    Inheritor.MESSAGES = copyPlainObject(this.MESSAGES);
+    Inheritor.DEFAULT_ERROR_LEVEL = this.DEFAULT_ERROR_LEVEL;
+
+    if (isObject(codes)) {
         Inheritor.extendCodes(codes);
     }
+
+    Inheritor.prototype.name = name;
 
     return Inheritor;
 };
@@ -98,62 +133,68 @@ Terror.create = function(name, codes) {
 /**
  * Extends existing CODE and MESSAGE hashes.
  * @param {Object} codes { CODE_NAME: 'error message', … }
- * @returns {Function} constructor
- * @throws TerrorError if collisions detected.
+ * @throws {Terror} TerrorError if collisions detected.
+ * @returns {Terror} constructor
  */
 Terror.extendCodes = function(codes) {
-    var ctor = this;
+    for (var code in codes) {
+        if (codes.hasOwnProperty(code)) {
+            if (this.CODES.hasOwnProperty(code)) {
+                throw Terror.createError(null, ERROR_CODE).bind({
+                    name: this.prototype.name,
+                    code: code
+                });
+            }
 
-    Object.keys(codes).forEach(function(code) {
-        if (_has(ctor.CODES, code)) {
-            throw new Error('Terror codes collision detected in the ' +
-                ctor.prototype.name + '.extendCodes call for code "' + code + '"');
+            this.CODES[code] = code;
+            this.MESSAGES[code] = codes[code];
         }
-
-        ctor.CODES[code] = code;
-        ctor.MESSAGES[code] = codes[code];
-    });
+    }
 
     return this;
 };
 
 /**
- * Default logger writes error message to console using logMultilineError
- * @param {String} message
- * @param {String} [level=DEBUG]
+ * @param {String|Number} [code]
+ * @param {String|Error|Object} [message] error message, Error or key-value hash for binding
+ * @returns {Terror} new Terror instance
  */
-Terror.prototype.logger = function(message, level) {
-    this.logMultilineError(message, level);
-};
+Terror.createError = function(code, message) {
+    var Const = this === Terror ? Terror : this;
+    var msg;
+    var data;
 
-Terror.DEFAULT_ERROR_LEVEL = 'ERROR';
-
-function _defaultLog(msg) {
-    console.log(msg);
-}
-
-/**
- * Default multiine error formatiing for simple text loggers,
- * such as console.log or any one, which write message as line in the text file.
- * @param {String} message
- * @param {String} level
- * @param {Function} [log=console.log] (String formattedMessageRow)
- */
-Terror.prototype.logMultilineError = function(message, level, log) {
-    var _level = (level || this.constructor.DEFAULT_ERROR_LEVEL).toUpperCase(),
-        _arrows = '\n' + _level.replace(/./g, '>') + ' ',
-        _log = log;
-
-    if (typeof _log !== 'function') {
-        _log = _defaultLog;
+    if (isString(message) || isError(message)) {
+        msg = message;
+    } else {
+        data = message;
     }
 
-    _log(_level + ' ' + message.replace(/\n/g, _arrows));
+    var error = new Const(code, msg).bind(data);
+
+    return captureStackTrace(error, this.createError);
+};
+
+/**
+ * @param {Error|Terror} error
+ * @param {String|Number} [code]
+ * @returns {Terror}
+ */
+Terror.ensureError = function(error, code) {
+    return error instanceof this ? error : this.createError(code, error);
+};
+
+/**
+ * @param {*} error
+ * @returns {Boolean}
+ */
+Terror.isTerror = function(error) {
+    return error && error._isTerror === true;
 };
 
 /**
  * @param {Function} logger (String message, String errorLevel)
- * @returns {Function} constructor
+ * @returns {Terror} constructor
  */
 Terror.setLogger = function(logger) {
     this.prototype.logger = logger;
@@ -162,18 +203,106 @@ Terror.setLogger = function(logger) {
 };
 
 /**
+ * @default 'Terror'
+ * @type {String}
+ */
+Terror.prototype.name = 'Terror';
+
+/**
  * @param {*} [level] – error level, any value allowed by logger
  * @returns {Terror} self
  */
 Terror.prototype.log = function(level) {
-    if (this._isLogged || ! this.logger) {
+    if (this._isLogged || isNotFunction(this.logger)) {
         return this;
     }
 
-    this.logger(this.code + ' ' + this.stack, level);
+    this.logger(this.getFullStack(), level);
     this._isLogged = true;
 
     return this;
+};
+
+/**
+ * Default logger writes error message to console using logMultilineError
+ * @param {String} message
+ * @param {String} [level=ERROR]
+ */
+Terror.prototype.logger = function(message, level) {
+    this.logMultilineError(message, level);
+};
+
+/**
+ * Default multiine error formatiing for simple text loggers,
+ * such as console.log or any one, which write message as line in the text file.
+ * @param {String} message
+ * @param {String} [level=ERROR]
+ * @param {Function} [log=console.log] (String formattedMessageRow)
+ * @returns {Terror}
+ */
+Terror.prototype.logMultilineError = function(message, level, log) {
+    var _level = (level || this.constructor.DEFAULT_ERROR_LEVEL).toUpperCase();
+    var _log = log;
+    var arrows = '\n' + new Array(_level.length + 1).join('>') + ' ';
+
+    if (isNotFunction(_log)) {
+        _log = defaultLog;
+    }
+
+    _log(_level + ' ' + message.replace(/\n/g, arrows));
+
+    return this;
+};
+
+/**
+ *
+ * @returns {String}
+ */
+Terror.prototype.getFullMessage = function() {
+    var error = this;
+    var result = '';
+    var msg;
+
+    do {
+        msg = error.message;
+
+        if (msg) {
+            if (msg[msg.length - 1] !== '.') {
+                msg += '.';
+            }
+
+            result += ' ' + msg;
+        }
+
+        error = error.originalError;
+    } while (error);
+
+    return this.code + result;
+};
+
+/**
+ *
+ * @returns {String}
+ */
+Terror.prototype.getFullStack = function() {
+    var error = this;
+    var result = new Array(0);
+    var indent = '';
+    var stack;
+
+    do {
+        if (error.stack) {
+            stack = String(error.stack).replace(/\n/g, '\n' + indent) + '\n';
+        } else {
+            stack = error.name + ': ' + error.message;
+        }
+
+        result.push(indent + error.code + ' ' + stack);
+
+        indent += '    ';
+    } while ((error = error.originalError));
+
+    return result.join('\n');
 };
 
 /**
@@ -181,83 +310,107 @@ Terror.prototype.log = function(level) {
  * @returns {Terror} self
  */
 Terror.prototype.bind = function(data) {
-    if (this.message.indexOf('%') > -1) {
-        this.setMessage(this.message.replace(/%([^%\s]+)%/g, function(match, name) {
-            return _has(data, name) ? data[name] : match;
-        }));
+    if (data == null) {
+        return this;
     }
 
-    Object.keys(data)
-        .forEach(function(propName) {
+    for (var propName in data) {
+        if ({}.hasOwnProperty.call(data, propName)) {
             this.data[propName] = data[propName];
-        }, this);
-
-    return this;
-};
-
-Terror.CODES = {
-    UNKNOWN_ERROR: 'UNKNOWN_ERROR'
-};
-
-Terror.MESSAGES = {
-    UNKNOWN_ERROR: 'Unknown error'
-};
-
-Terror.prototype.setMessage = function(message) {
-    this.message = message;
-    // patch stacktrace
-    this.stack = this._stackTemplate.replace('$$MESSAGE$$', message);
-    return this;
-};
-
-/**
- * @param {Number} code
- * @param {String|Error|Object} [message] error message, Error or key-value hash for binding
- * @returns {Terror} new Terror instance
- */
-Terror.createError = function(code, message) {
-    var Constructor = this,
-        error = new Constructor(code),
-        _msg = error.message;
-
-    // patch stacktrace to avoid meaningless entry of createError call
-    error.message = '$$MESSAGE$$';
-    Error.captureStackTrace(error, this.createError);
-    error._stackTemplate = error.stack;
-    error.setMessage(_msg);
-
-    if (message instanceof Error || typeof message === 'string') {
-        error.originalError = message;
-        error.setMessage(error.message + ' (' + message.toString() + ')');
-    } else if (typeof message === 'object' && message !== null) {
-        error.bind(message);
+        }
     }
 
-    return error;
+    return this.setMessage(this.message);
 };
 
 /**
- * @param {Error|Terror} error
- * @param {Number} [code]
+ *
+ * @param {String} message
  * @returns {Terror}
  */
-Terror.ensureError = function(error, code) {
-    if ( ! (error instanceof this)) {
-        if (typeof code !== 'string') {
-            code = this.CODES.UNKNOWN_ERROR;
+Terror.prototype.setMessage = function(message) {
+    this.message = isString(message) && message.indexOf('%') > -1 ? sPrintF(message, this.data) : message;
+
+    return this;
+};
+
+function isError(value) {
+    return value instanceof Error;
+}
+
+function isString(value) {
+    return typeof value === 'string';
+}
+
+function isObject(value) {
+    return typeof value === 'object' && value !== null;
+}
+
+function isNotFunction(fnc) {
+    return typeof fnc !== 'function';
+}
+
+function defaultLog(msg) {
+    console.log(msg);
+}
+
+function sPrintF(str, data) {
+    var result = '';
+    var m;
+    var last = 0;
+    var regExp = /%([^%\s]+)%/g;
+
+    while ((m = regExp.exec(str))) {
+        result += str.substring(last, m.index) + (data.hasOwnProperty(m[1]) ? data[m[1]] : m[0]);
+        last = m.index + m[0].length;
+    }
+
+    return result + str.substr(last);
+}
+
+function copyPlainObject(src) {
+    var object = {};
+
+    for (var key in src) {
+        if (src.hasOwnProperty(key)) {
+            object[key] = src[key];
         }
-        error = this.createError(code, error);
+    }
+
+    return object;
+}
+
+function captureStackTrace(error, fnc) {
+    if (Error.captureStackTrace) {
+        var stackTraceLimit = Error.stackTraceLimit;
+
+        Error.stackTraceLimit = error.constructor.stackTraceLimit;
+        Error.captureStackTrace(error, fnc);
+        Error.stackTraceLimit = stackTraceLimit;
     }
 
     return error;
-};
+}
 
-/**
- * @param {Error|Terror} error
- * @returns {Boolean}
- */
-Terror.isTerror = function(error) {
-    return error._isTerror === true;
-};
+function inherits(Ctor, SuperCtor) {
+    if (Object.create) {
+        Ctor.prototype = Object.create(SuperCtor.prototype, {
+            constructor: {
+                value: Ctor,
+                enumerable: false,
+                writable: true,
+                configurable: true
+            }
+        });
+    } else {
+        Const.prototype = SuperCtor.prototype;
+        new Const(Ctor);
+    }
+}
 
-module.exports = Terror;
+function Const(ctor) {
+    this.constructor = ctor;
+    ctor.prototype = this;
+
+    Const.prototype = Object.prototype;
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "terror",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Base error class which will help you grep logs more effectively",
   "main": "./lib/terror.js",
   "scripts": {
-    "test": "jshint --config .jshintrc lib test && jscs lib test && mocha -u exports test"
+    "test": "jshint --config .jshintrc lib test && jscs lib test && jasmine"
   },
   "repository": {
     "type": "git",
@@ -34,6 +34,7 @@
     "chai": "^1.10.0",
     "jscs": "1.4.x",
     "jshint": "^2.1.0",
-    "mocha": "^2.0.1"
+    "mocha": "^2.0.1",
+    "jasmine": "2.0.1"
   }
 }

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,6 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ]
+}

--- a/spec/terror.spec.js
+++ b/spec/terror.spec.js
@@ -1,0 +1,594 @@
+var Terror = require('../lib/terror');
+
+describe('Terror.', function () {
+    var terror;
+    var error;
+    var data;
+    var MyError;
+    var customLogger = jasmine.createSpy();
+
+    console.log = customLogger;
+
+    function checkInstance(code, message, original, data, name) {
+        expect(terror.code).toBe(code);
+        expect(terror.message).toBe(message);
+        expect(terror.originalError).toBe(original);
+
+        if (arguments.length >= 4) {
+            expect(terror.data).toEqual(data);
+        } else {
+            expect(terror.data).toEqual({});
+        }
+
+        if (arguments.length === 5) {
+            expect(terror.name).toBe(name);
+        } else {
+            expect(terror.name).toBe('Terror');
+        }
+    }
+
+    beforeEach(function () {
+        terror = new Terror();
+    });
+
+    it('Check exports', function () {
+        expect(typeof Terror).toBe('function');
+        expect(Terror.DEFAULT_ERROR_LEVEL).toBe('ERROR');
+
+        expect(Terror.CODES).toEqual({
+            UNKNOWN_ERROR: 'UNKNOWN_ERROR'
+        });
+
+        expect(Terror.MESSAGES).toEqual({
+            UNKNOWN_ERROR: 'Unknown error'
+        });
+    });
+
+    it('Prototype should be inherit from Error', function () {
+        expect(Terror.prototype instanceof Error).toBeTruthy();
+        expect(Terror.prototype.constructor).toBe(Terror);
+    });
+
+    describe('Create instance.', function () {
+        it('Check inherits', function () {
+            expect(terror instanceof Error).toBeTruthy();
+            expect(terror instanceof Terror).toBeTruthy();
+
+            expect(terror.constructor).toBe(Terror);
+        });
+
+        it('Check error code', function () {
+            terror = new Terror();
+            checkInstance('UNKNOWN_ERROR', 'Unknown error');
+
+            terror = new Terror(null);
+            checkInstance('UNKNOWN_ERROR', 'Unknown error');
+
+            terror = new Terror('code');
+            checkInstance('code');
+        });
+
+        it('Check message', function () {
+            terror = new Terror('code', 'message');
+            checkInstance('code', 'message');
+
+            terror = new Terror(null, 'message');
+            checkInstance('UNKNOWN_ERROR', 'message');
+        });
+
+        it('Define original error', function () {
+            error = new Error('message');
+            terror = new Terror(null, error);
+
+            checkInstance('UNKNOWN_ERROR', 'Unknown error', error);
+
+            terror = new Terror('code', error);
+            checkInstance('code', undefined, error);
+        });
+
+        it('Check capture stack trace', function () {
+            var error = new Error().stack.split('\n')[1];
+            var terror = new Terror().stack.split('\n')[1];
+
+            expect(error.substr(0, error.length - 7)).toBe(terror.substr(0, terror.length - 7));
+        });
+    });
+
+    describe('Terror.createError', function () {
+        it('Check inherits', function () {
+            terror = Terror.createError();
+
+            expect(terror instanceof Error).toBeTruthy();
+            expect(terror instanceof Terror).toBeTruthy();
+
+            expect(terror.constructor).toBe(Terror);
+        });
+
+        it('Check error code', function () {
+            terror = new Terror();
+            checkInstance('UNKNOWN_ERROR', 'Unknown error');
+
+            terror = Terror.createError(null);
+            checkInstance('UNKNOWN_ERROR', 'Unknown error');
+
+            terror = Terror.createError('code');
+            checkInstance('code');
+        });
+
+        it('Check message', function () {
+            terror = Terror.createError('code', 'message');
+            checkInstance('code', 'message');
+
+            terror = Terror.createError(null, 'message');
+            checkInstance('UNKNOWN_ERROR', 'message');
+        });
+
+        it('Define original error', function () {
+            error = new Error('message');
+            terror = Terror.createError(null, error);
+
+            checkInstance('UNKNOWN_ERROR', 'Unknown error', error);
+
+            terror = Terror.createError('code', error);
+            checkInstance('code', undefined, error);
+        });
+
+        it('Check capture stack trace', function () {
+            var error = new Error().stack.split('\n')[1];
+            var terror = Terror.createError().stack.split('\n')[1];
+
+            expect(error.substr(0, error.length - 7)).toBe(terror.substr(0, terror.length - 7));
+        });
+
+        it('Should bind a data', function () {
+            data = {
+                name: 'value'
+            };
+            terror = Terror.createError(null, data);
+
+            checkInstance('UNKNOWN_ERROR', 'Unknown error', undefined, data);
+            expect(terror.data).not.toBe(data);
+        });
+    });
+
+    describe('Terror.create', function () {
+        it('Check inherits', function () {
+            MyError = Terror.create('MyError');
+
+            expect(typeof MyError).toBe('function');
+            expect(MyError.name).toBe('MyError');
+            expect(MyError.prototype instanceof Terror).toBeTruthy();
+            expect(MyError.prototype.constructor).toBe(MyError);
+        });
+
+        it('Check static properties', function () {
+            MyError = Terror.create('MyError');
+
+            expect(MyError.create).toBe(Terror.create);
+            expect(MyError.extendCodes).toBe(Terror.extendCodes);
+            expect(MyError.setLogger).toBe(Terror.setLogger);
+            expect(MyError.createError).toBe(Terror.createError);
+            expect(MyError.ensureError).toBe(Terror.ensureError);
+            expect(MyError.stackTraceLimit).toBe(Terror.stackTraceLimit);
+
+            expect(MyError.CODES).toEqual(Terror.CODES);
+            expect(MyError.CODES).not.toBe(Terror.CODES);
+
+            expect(MyError.MESSAGES).toEqual(Terror.MESSAGES);
+            expect(MyError.MESSAGES).not.toBe(Terror.MESSAGES);
+
+            expect(MyError.DEFAULT_ERROR_LEVEL).toBe(Terror.DEFAULT_ERROR_LEVEL);
+        });
+
+        it('Check multiple inheritance', function () {
+            MyError = Terror.create('MyError');
+
+            var Child = MyError.create('Child');
+
+            terror = new Child();
+
+            expect(terror instanceof Child).toBeTruthy();
+            expect(terror instanceof MyError).toBeTruthy();
+
+            checkInstance('UNKNOWN_ERROR', 'Unknown error', undefined, {}, 'Child');
+        });
+
+        it('Check instance', function () {
+            MyError = Terror.create('MyError');
+            terror = new MyError();
+
+            expect(terror instanceof MyError).toBeTruthy();
+            expect(terror instanceof Terror).toBeTruthy();
+            expect(terror instanceof Error).toBeTruthy();
+
+            checkInstance('UNKNOWN_ERROR', 'Unknown error', undefined, {}, 'MyError');
+        });
+
+        it('Should merge CODES and MESSAGES', function () {
+            MyError = Terror.create('MyError', {
+                CODE: 'Message'
+            });
+
+            expect(MyError.CODES).toEqual({
+                UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+                CODE: 'CODE'
+            });
+
+            expect(MyError.MESSAGES).toEqual({
+                UNKNOWN_ERROR: 'Unknown error',
+                CODE: 'Message'
+            })
+        });
+    });
+
+    it('Terror.isTerror', function () {
+        expect(Terror.isTerror()).toBeFalsy();
+        expect(Terror.isTerror(null)).toBeFalsy();
+        expect(Terror.isTerror(123)).toBeFalsy();
+        expect(Terror.isTerror('error')).toBeFalsy();
+        expect(Terror.isTerror({})).toBeFalsy();
+        expect(Terror.isTerror(new Error('error'))).toBeFalsy();
+
+        expect(Terror.isTerror(new Terror())).toBeTruthy();
+        expect(Terror.create('MyError').createError()).toBeTruthy();
+        expect(Terror.isTerror({
+            _isTerror: true
+        })).toBeTruthy();
+    });
+
+    describe('Terror.extendCodes', function () {
+        it('Should return current context', function () {
+            expect(Terror.extendCodes({})).toBe(Terror);
+
+            MyError = Terror.create('MyError');
+            expect(MyError.extendCodes({})).toBe(MyError);
+        });
+
+        it('Should merge CODES and MESSAGES', function () {
+            MyError = Terror
+                .create('MyError')
+                .extendCodes({
+                    CODE: 'Message'
+                });
+
+            expect(MyError.CODES).toEqual({
+                UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+                CODE: 'CODE'
+            });
+
+            expect(MyError.MESSAGES).toEqual({
+                UNKNOWN_ERROR: 'Unknown error',
+                CODE: 'Message'
+            });
+        });
+
+        it('Should throw an exception if a code is exists', function () {
+            expect(function () {
+                Terror.extendCodes({
+                    UNKNOWN_ERROR: 'Unknown error'
+                });
+            }).toThrow();
+        });
+    });
+
+    describe('Terror.ensureError', function () {
+        it('Should don`t wrap if the message it is instance of a current constructor', function () {
+            terror = new Terror();
+            expect(Terror.ensureError(terror)).toBe(terror);
+
+            MyError = Terror.create('MyError');
+            terror = new MyError();
+            expect(MyError.ensureError(terror)).toBe(terror);
+        });
+
+        it('Should wrap if the message is not an error', function () {
+            terror = Terror.ensureError(123);
+            checkInstance('UNKNOWN_ERROR', 'Unknown error');
+
+            terror = Terror.ensureError({});
+            checkInstance('UNKNOWN_ERROR', 'Unknown error');
+
+            terror = Terror.ensureError();
+            checkInstance('UNKNOWN_ERROR', 'Unknown error');
+
+            terror = Terror.ensureError(null);
+            checkInstance('UNKNOWN_ERROR', 'Unknown error');
+        });
+
+        it('Should set an original error if message is a error', function () {
+            error = new Error('error');
+            terror = Terror.ensureError(error);
+            checkInstance('UNKNOWN_ERROR', 'Unknown error', error);
+        });
+
+        it('Should set the property message, if the argument is an error message', function () {
+            terror = Terror.ensureError('message');
+            checkInstance('UNKNOWN_ERROR', 'message');
+        });
+
+        it('Should wrap if the message is not instance of this constructor', function () {
+            MyError = Terror.create('MyError');
+
+            error = new Terror();
+            terror = MyError.ensureError(error);
+            checkInstance('UNKNOWN_ERROR', 'Unknown error', error, {}, 'MyError');
+        });
+
+        it('Should don`t wrap if the message inherits from current constructor', function () {
+            terror = new Terror();
+            expect(Terror.ensureError(terror)).toBe(terror);
+
+            MyError = Terror.create('MyError');
+            terror = new MyError();
+            expect(Terror.ensureError(terror)).toBe(terror);
+        });
+
+        it('Should set a code of an error', function () {
+            terror = Terror.ensureError('message', 'code');
+            checkInstance('code', 'message');
+
+            error = new Terror();
+            terror = Terror.ensureError(error, 'code');
+            checkInstance('UNKNOWN_ERROR', 'Unknown error');
+        });
+    });
+
+    it('Terror.setLogger', function () {
+        var defaultLogger = terror.logger;
+        var logger = function () {};
+
+        Terror.setLogger(logger);
+
+        expect(terror.logger).toBe(logger);
+
+        Terror.setLogger(defaultLogger);
+    });
+
+    describe('Terror.stackTraceLimit', function () {
+        afterEach(function () {
+            Terror.stackTraceLimit = 10;
+        });
+
+        it('Should be default is 10', function () {
+            expect(Terror.stackTraceLimit).toBe(10);
+        });
+
+        it('Check effect', function () {
+            Terror.stackTraceLimit = 5;
+
+            terror = new Terror();
+
+            expect(terror.stack.split('\n').length).toBe(6);
+        });
+
+        it('Stack trace should be empty if value set to 0', function () {
+            Terror.stackTraceLimit = 0;
+
+            terror = new Terror();
+
+            expect((terror.stack || '').split('\n').length).toBe(1);
+        });
+
+        it('Change for custom error', function () {
+            MyError = Terror.create('MyError');
+
+            MyError.stackTraceLimit = 5;
+
+            expect(Terror.stackTraceLimit).toBe(10);
+
+            terror = new MyError();
+            expect(terror.stack.split('\n').length).toBe(6);
+
+            terror = new Terror();
+            expect(terror.stack.split('\n').length).toBe(11);
+        });
+
+        it('Stack trace limit should be equal to parent', function () {
+            Terror.stackTraceLimit = 5;
+
+            MyError = Terror.create('MyError');
+
+            expect(MyError.stackTraceLimit).toBe(5);
+
+            Terror.stackTraceLimit = 10;
+        });
+    });
+
+    describe('Terror#bind', function () {
+        it('Should returns a instance of terror', function () {
+            expect(terror.bind()).toBe(terror);
+        });
+
+        it('Should copy bind object', function () {
+            data = {
+                name: 'value'
+            };
+
+            terror.bind(data);
+
+            expect(terror.data).toEqual(data);
+            expect(terror.data).not.toBe(data);
+        });
+
+        it('Should change message', function () {
+            terror.setMessage('message %name% ');
+
+            expect(terror.message).toBe('message %name% ');
+
+            terror.bind({
+                name: 'value'
+            });
+
+            expect(terror.message).toBe('message value ');
+        });
+
+        it('Don`t should change message if data equal null or undefined', function () {
+            terror
+                .setMessage('message %name% ')
+                .bind();
+
+            expect(terror.message).toBe('message %name% ');
+
+            terror.bind(null);
+
+            expect(terror.message).toBe('message %name% ');
+        });
+    });
+
+    it('Terror#setMessage', function () {
+        var message = 'error %code% %message%';
+
+        terror
+            .bind({
+                code: 100,
+                message: 'message',
+                some: 'bar'
+            })
+            .setMessage(message);
+
+        expect(terror.message).toBe('error 100 message');
+
+        terror.setMessage('error');
+
+        expect(terror.message).toBe('error');
+    });
+
+    describe('Terror#logger', function () {
+        it('should be default call Terror#logMultilineError', function () {
+            terror.logMultilineError = jasmine.createSpy();
+
+            terror.logger('message', 'error');
+
+            expect(terror.logMultilineError).toHaveBeenCalledWith('message', 'error');
+        });
+    });
+
+    describe('Terror#log', function () {
+        it('should returns the current context', function () {
+            expect(terror.log()).toBe(terror);
+        });
+
+        it('should use default console.log', function () {
+            terror.log();
+
+            expect(customLogger).toHaveBeenCalled();
+
+            customLogger.calls.reset();
+        });
+
+        it('should call Terror#logger with full stack and log level', function () {
+            terror.logger = jasmine.createSpy();
+            terror.log('error');
+
+            expect(terror.logger).toHaveBeenCalledWith(terror.getFullStack(), 'error');
+        });
+
+        it('should be once log', function () {
+            terror.logger = jasmine.createSpy();
+            terror.log('error');
+            terror.log('error');
+
+            expect(terror.logger.calls.count()).toBe(1);
+        });
+
+        it('should don`t log if logger is not a function', function () {
+            terror.logger = null;
+            terror.log();
+
+            expect(customLogger).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Terror#logMultilineError', function () {
+        var logger = jasmine.createSpy();
+
+        afterEach(function () {
+            logger.calls.reset();
+        });
+
+        it('should be returns the current context', function () {
+            expect(terror.logMultilineError('message')).toBe(terror);
+        });
+
+        it('should use default log level', function () {
+            terror.logMultilineError('message', null, logger);
+
+            expect(logger).toHaveBeenCalledWith('ERROR message');
+        });
+
+        it('should use default console.log', function () {
+            terror.logMultilineError('message');
+
+            expect(customLogger).toHaveBeenCalled();
+
+            customLogger.calls.reset();
+        });
+
+        it('should use custom logger', function () {
+            terror.logMultilineError('message', 'Debug', logger);
+
+            expect(logger).toHaveBeenCalledWith('DEBUG message');
+        });
+
+        it('should add arrows to stack', function () {
+            var stack = terror.stack.split('\n');
+
+            terror.logMultilineError(terror.stack, 'ERR', function (message) {
+                message = message.split('\n');
+
+                var length = message.length;
+                var index = 1;
+
+                expect(index < length).toBeTruthy();
+
+                while (index < length) {
+                    expect(message[index]).toBe('>>> ' + stack[index]);
+
+                    index++;
+                }
+            });
+        });
+    });
+
+    describe('Terror#getFullMessage', function () {
+        var myError;
+
+        beforeEach(function () {
+            MyError = Terror.create('MyError', {
+                MY_CODE: 'Some message'
+            });
+        });
+
+        it('should includes all messages', function () {
+            terror = new Terror(null, 'Parent message');
+            myError = new MyError('MY_CODE', terror);
+
+            expect(myError.getFullMessage()).toBe('MY_CODE Some message. Parent message.')
+        });
+
+        it('should don`t include empty message', function () {
+            terror = new Terror();
+            myError = new MyError('MY_CODE', terror).setMessage(null);
+
+            expect(myError.getFullMessage()).toBe('MY_CODE Unknown error.');
+        });
+
+        it('should be format error message', function () {
+            terror = new Terror(null, 'Error');
+            myError = new MyError('MY_CODE', terror).setMessage('My message.');
+
+            expect(myError.getFullMessage()).toBe('MY_CODE My message. Error.');
+        });
+    });
+
+    it('Terror#getFullStack', function () {
+        MyError = Terror.create('MyError');
+        MyError.stackTraceLimit = 3;
+
+        var stack = new MyError(null, new Terror()).getFullStack().split('\n');
+
+        expect(stack.length).toBe(17);
+        expect(stack[0]).toBe('UNKNOWN_ERROR MyError: Unknown error');
+        expect(stack[5]).toBe('    UNKNOWN_ERROR Terror: Unknown error');
+    });
+});

--- a/test/terror.js
+++ b/test/terror.js
@@ -1,5 +1,5 @@
 var test = require('chai').assert,
-    Terror = require('../lib/terror'),
+    Terror = require('../lib/Terror'),
     originalConsoleLog = console.log,
     log = [];
 
@@ -69,7 +69,9 @@ module.exports = {
         test.strictEqual(terrorWithZeroErrorCode.code, TestError.CODES.ABSOLUTE_ERROR, 'error with zero code doesn\'t use default code');
 
         test.strictEqual(terrorWithMessage.code, TestError.CODES.USER_ERROR, 'error code passed to createError with custom message');
-        test.strictEqual(terrorWithMessage.originalError, errorMessage, 'custom message passed to createError');
+
+        // Строка сообщения об ошибке не является оригинальным объектом ошибки!
+        test.equal(terrorWithMessage.originalError, null, 'custom message passed to createError');
 
         test.notStrictEqual(TestError.CODES, Terror.CODES, 'static field CODE deep copied');
         test.notStrictEqual(TestError.MESSAGES, Terror.MESSAGES, 'static field MESSAGES deep copied');
@@ -107,12 +109,12 @@ module.exports = {
             testCodes = { USER_ERROR : 'User "%username%" leads to error at %time%' },
             TestError = Terror.create(errorClassName).extendCodes(testCodes),
             errorMessage = 'Test Error message',
-            userName = 'john_doe',
-            time = '12:05',
+            //userName = 'john_doe',
+            //time = '12:05',
             errorLevel = 'panic',
             originalError = new Error(errorMessage),
             terrorByError = TestError.createError(null, originalError),
-            terrorWithData = TestError.createError(TestError.CODES.USER_ERROR, { username : userName, time : time }),
+            //terrorWithData = TestError.createError(TestError.CODES.USER_ERROR, { username : userName, time : time }),
             terrorWithMessage = TestError.createError(TestError.CODES.USER_ERROR, errorMessage);
 
         catchConsoleLog();
@@ -128,12 +130,13 @@ module.exports = {
             TestError.DEFAULT_ERROR_LEVEL.replace(/./g, '>'),
             'error level replaced with ">"');
 
-        test.strictEqual(log[0].split(' ')[2].replace(/:$/g, ''), errorClassName, 'log error class name');
+        //test.strictEqual(log[0].split(' ')[2].replace(/:$/g, ''), errorClassName, 'log error class name');
 
-        test.strictEqual(
+        // Сообщение об ошибке не дублируется!
+        /*test.strictEqual(
             log[0].split(' ').slice(3).join(' ').replace(/^.*\(Error: (.*)\)$/g, "$1"),
             errorMessage,
-            'log original error message');
+            'log original error message');*/
 
         catchConsoleLog();
         terrorByError.log();
@@ -145,27 +148,27 @@ module.exports = {
         terrorWithMessage.log(errorLevel);
         restoreConsoleLog();
 
-        test.strictEqual(
+        /*test.strictEqual(
             log[0].split(' ').slice(3).join(' ').replace(/.*\((.*)\)$/g, "$1"),
             errorMessage,
-            'append original error message');
+            'append original error message');*/
         test.strictEqual(
             log[0].split(' ')[0],
             errorLevel.toUpperCase(),
             'custom error level passed to logError');
-        test.strictEqual(
+        /*test.strictEqual(
             log[0].split(' ')[1],
             TestError.CODES.USER_ERROR,
-            'custom error code');
+            'custom error code');*/
 
-        catchConsoleLog();
+        /*catchConsoleLog();
         terrorWithData.log();
         restoreConsoleLog();
 
         test.strictEqual(
             log[0].split(' ').slice(3).join(' '),
             TestError.MESSAGES[TestError.CODES.USER_ERROR].replace('%username%', userName).replace('%time%', time),
-            'data binding via createError');
+            'data binding via createError');*/
     },
 
     "bind" : function() {
@@ -174,24 +177,24 @@ module.exports = {
                 TO_STRING_TEST : '%toString%'
             },
             TestError = Terror.create('TestError').extendCodes(testCodes),
-            userName = 'john_doe',
-            time = '12:04',
-            terrorNotBinded = TestError.createError(TestError.CODES.USER_ERROR),
-            terrorBinded = TestError
+            //userName = 'john_doe',
+            //time = '12:04',
+            terrorNotBinded = TestError.createError(TestError.CODES.USER_ERROR)
+            /*terrorBinded = TestError
                 .createError(TestError.CODES.USER_ERROR)
                 .bind({ username : userName, time : time }),
-            terrorProto = TestError.createError(TestError.CODES.TO_STRING_TEST);
+            terrorProto = TestError.createError(TestError.CODES.TO_STRING_TEST)*/;
 
         catchConsoleLog();
         terrorNotBinded.log();
         restoreConsoleLog();
 
-        test.strictEqual(
+        /*test.strictEqual(
             log[0].split(' ').slice(3).join(' '),
             TestError.MESSAGES[TestError.CODES.USER_ERROR],
-            'not binded error message contains placeholder');
+            'not binded error message contains placeholder');*/
 
-        catchConsoleLog();
+        /*catchConsoleLog();
         terrorBinded.log();
         restoreConsoleLog();
 
@@ -208,9 +211,10 @@ module.exports = {
         test.strictEqual(
             log[0].split(' ').slice(3).join(' '),
             TestError.MESSAGES[TestError.CODES.TO_STRING_TEST],
-            'placeholder still here');
+            'placeholder still here');*/
 
-        terrorProto._isLogged = false;
+        // Стек формируется один раз!
+        /*terrorProto._isLogged = false;
         terrorProto.bind({ toString : userName });
         catchConsoleLog();
         terrorProto.log();
@@ -218,11 +222,11 @@ module.exports = {
 
         test.strictEqual(
             log[0].split(' ').slice(3).join(' '),
-            userName,
+            TestError.MESSAGES[TestError.CODES.TO_STRING_TEST],
             'placeholder still here');
 
         test.strictEqual(terrorBinded.data.username, userName,
-            'binded data available via `data` property');
+            'binded data available via `data` property');*/
     },
 
     "ensureError" : function() {


### PR DESCRIPTION
#### Предпосылки для изменений:
* Хотелось реализовать поддержку стратегии обработки ошибок, при которой инстанс оборачивается на каждом логическом уровне приложения. Нехватало логирования стека всех экземпляров, а так же полного человекопонятного сообщения об ошибке. Про эту стратегию можно почитать [здесь] (http://habrahabr.ru/post/222761/).
* В текущей реализации создание и логирование ошибок занимало заметное количество времени из-за формирования стека для каждого экземпляра, что совершенно ненужно. В нормальном боевом окружении разница в производительности может быть не заметна.

#### Changelog:
* `Terror` теперь может принимать вторым аргументом объект `error`.
* Если вторым аргументом была передана строка, она не попадает в свойство `originalError`. Существуют сторонние обертки над ошибками, использующие значение из этого свойства. Если в нем содержится что-то отличное от `error`, возникало исключение при работе с `terror.originalError.stack`.
* Свойство `Terror#message` содержит только оригинальное сообщение текущего объекта.
* Новое свойство `Terror.stackTraceLimit` позволяет ограничивать глубину формируемого стека ошибки (если поддерживается интерпретатором). Может быть переопределено для любого конструктора, наследуемого от `Terror`. С помощью данного свойства можно сильно снизить нагрузку на процессор, если устанавить его значение в 0 на высоких уровнях приложения.
* `Terror.isTerror` теперь не падает, если передать `null` или `undefined`.
* `Terror#log` теперь логирует стеки всех обернутых ошибок.
* Новый метод `Terror#getFullMessage` возвращает полное сообщение об ошибке, включая сообщения обернутых экземпляров. Сообщение каждого объекта ошибки воспринимается как предложение. Формат возвращаемого значения: `ERR_CODE Can not create page. Can not instance widget. a is no a function.`
* Новый метод `Terror#getFullStack` возвращает стеки всех обернутых экземпляров. Каждый последующий стек отбивается четыремя пробелами слева (стандартный отступ стека). К каждому сообщению об ошибке добавляется код.
* `Terror#setMessage` теперь не меняет сообщение в сформированном стеке.
* Кастомные конструкторы теперь имеют полноценное имя (`MyError.name`).
* Оптимизация производительности: `cd benchmark; npm test`.
* Тесты переписаны на jasmine.
* `Terror` теперь не зависит от NodeJS и может выполняться в любом окружении ([Issuse #1] (https://github.com/nodules/terror/issues/1)).
* Мог что-то упустить.

#### Что нужно сделать:
* Портировать тесты на mocha, раз вы используете его. Удалить старые тесты.
* Решить с форматом `Terror#getFullStack`, так как он сейчас жестко зашит в метод. Я бы оставил и так, ничего криминального в этом нет. `Terror#logMultilineError` тоже этим грешит.
* Обновить `README.md` и JSDoc. Мой английский не позволяет это сделать грамотно.
* Что-нибудь еще?